### PR TITLE
#26 Add a new Spider to check delinquent properties

### DIFF
--- a/dayton/spiders/dayton_tax_delinquency_spider.py
+++ b/dayton/spiders/dayton_tax_delinquency_spider.py
@@ -1,0 +1,84 @@
+import csv
+import glob
+import urllib.request
+
+import scrapy
+from scrapy.selector import Selector
+
+from dayton.spiders.reap_spider import unzip
+
+
+class DelinquencySpider(scrapy.Spider):
+    """This class is used to parse the delinquency tax information CSV files from the
+    Montgomery County Treasurers Website and output any properties that have larger
+    net delinquent taxes than the value of the property and building.
+
+    The field descriptions from the file can be found here:
+    www.mctreas.org/mctreas/data/delq%20file%20layout.pdf
+    """
+
+    DAYTON_DELINQUENT_PROPERTIES_OUTFILE = "delinquent_tax_processed.csv"
+    name = 'dayton_tax_delinquency'
+    allowed_domains = ['mctreas.org', 'mcohio.org']
+    start_urls = [
+        'http://www.mctreas.org/mctreas/fdpopup.cfm?dtype=DQ'
+    ]
+
+    def parse(self, response, **kwargs) -> None:
+        """
+        Parses the delinquency file given. Writes the matching records to the output
+        file specified.
+
+        Args:
+            response: The HTTP response object from the crawled website.
+
+        Returns:
+            None
+
+        Raises:
+            ValueError if the necessary columns can't be found in the delinquency_file header
+        """
+        delinquent_link = Selector(response).xpath(
+            '//*[@id="box1"]/td[1]/li/font/i/a/@href').extract()
+        urllib.request.urlretrieve(response.urljoin(delinquent_link[0]),
+                                   'delinquent.zip')
+        unzip('delinquent.zip', 'delinquent')
+
+        with open(self.DAYTON_DELINQUENT_PROPERTIES_OUTFILE, mode="w") as out_file:
+            with open(glob.glob('delinquent/*.csv')[0], newline='') as delinquent_file:
+                header = delinquent_file.readline()
+                out_file.write(header)
+
+                delinquent_file_reader = csv.reader(delinquent_file)
+                out_file_writer = csv.writer(out_file)
+                value_index = None
+                owed_index = None
+                tax_district_index = None
+                for idx, val in enumerate(header.split(",")):
+                    if val.strip(' "') == "ASMTTOTAL":
+                        value_index = idx
+                    elif val.strip(' "') == "NETDELQ":
+                        owed_index = idx
+                    elif val.strip(' "') == "TXDST":
+                        tax_district_index = idx
+
+                if not all([value_index, owed_index, tax_district_index]):
+                    raise ValueError(
+                        f"One of the indexes wasn't set: "
+                        f"{value_index=} {owed_index=} {tax_district_index=}")
+
+                for row in delinquent_file_reader:
+                    if len(row) < len(header.split(",")):
+                        continue
+                    home_value: str = row[value_index].strip(' "')
+                    tax_owed: str = row[owed_index].strip(' "')
+                    tax_district: str = row[tax_district_index].strip(' "')
+                    if not home_value or not tax_owed:
+                        continue
+                    home_value: float = float(home_value)
+                    tax_owed: float = float(tax_owed)
+                    is_in_dayton = bool(tax_district) and tax_district == "R72"
+                    if home_value and tax_owed and tax_owed > home_value and is_in_dayton:
+                        out_file_writer.writerow(row)
+
+


### PR DESCRIPTION
## Changes
This commit adds a new spider that pulls the delinquency file from the Montgomery County treasurer's website and checks all the properties in Dayton for a tax delinquency that is greater than the properties assessed value. It then writes that information out to a CSV file for evaluation.

## Testing
```
scrapy runspider dayton_tax_delinquency_spider.py
2022-12-14 23:04:24 [scrapy.utils.log] INFO: Scrapy 2.7.1 started (bot: codefordayton)
2022-12-14 23:04:24 [scrapy.utils.log] INFO: Versions: lxml 4.9.1.0, libxml2 2.9.13, cssselect 1.2.0, parsel 1.7.0, w3lib 2.1.1, Twisted 22.10.0, Python 3.11.0 (v3.11.0:deaf509e8f, Oct 24 2022, 14:43:23) [Clang 13.0.0 (clang-1300.0.29.30)], pyOpenSSL 22.1.0 (OpenSSL 3.0.7 1 Nov 2022), cryptography 38.0.4, Platform macOS-13.0.1-arm64-arm-64bit
2022-12-14 23:04:24 [scrapy.crawler] INFO: Overridden settings:
{'BOT_NAME': 'codefordayton',
 'NEWSPIDER_MODULE': 'dayton.spiders',
 'SPIDER_LOADER_WARN_ONLY': True,
 'SPIDER_MODULES': ['dayton.spiders'],
 'USER_AGENT': 'dayton (+http://www.codefordayton.org)'}
2022-12-14 23:04:24 [py.warnings] WARNING: /Users/brianmuse/projects/scrapers/venv/lib/python3.11/site-packages/scrapy/utils/request.py:231: ScrapyDeprecationWarning: '2.6' is a deprecated value for the 'REQUEST_FINGERPRINTER_IMPLEMENTATION' setting.

It is also the default value. In other words, it is normal to get this warning if you have not defined a value for the 'REQUEST_FINGERPRINTER_IMPLEMENTATION' setting. This is so for backward compatibility reasons, but it will change in a future version of Scrapy.

See the documentation of the 'REQUEST_FINGERPRINTER_IMPLEMENTATION' setting for information on how to handle this deprecation.
  return cls(crawler)

2022-12-14 23:04:24 [py.warnings] WARNING: /Users/brianmuse/projects/scrapers/venv/lib/python3.11/site-packages/scrapy/extensions/feedexport.py:289: ScrapyDeprecationWarning: The `FEED_URI` and `FEED_FORMAT` settings have been deprecated in favor of the `FEEDS` setting. Please see the `FEEDS` setting docs for more details
  exporter = cls(crawler)

2022-12-14 23:04:24 [scrapy.middleware] INFO: Enabled extensions:
['scrapy.extensions.corestats.CoreStats',
 'scrapy.extensions.telnet.TelnetConsole',
 'scrapy.extensions.memusage.MemoryUsage',
 'scrapy.extensions.feedexport.FeedExporter',
 'scrapy.extensions.logstats.LogStats']
2022-12-14 23:04:25 [scrapy.middleware] INFO: Enabled downloader middlewares:
['scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware',
 'scrapy.downloadermiddlewares.downloadtimeout.DownloadTimeoutMiddleware',
 'scrapy.downloadermiddlewares.defaultheaders.DefaultHeadersMiddleware',
 'scrapy.downloadermiddlewares.useragent.UserAgentMiddleware',
 'scrapy.downloadermiddlewares.retry.RetryMiddleware',
 'scrapy.downloadermiddlewares.redirect.MetaRefreshMiddleware',
 'scrapy.downloadermiddlewares.httpcompression.HttpCompressionMiddleware',
 'scrapy.downloadermiddlewares.redirect.RedirectMiddleware',
 'scrapy.downloadermiddlewares.cookies.CookiesMiddleware',
 'scrapy.downloadermiddlewares.httpproxy.HttpProxyMiddleware',
 'scrapy.downloadermiddlewares.stats.DownloaderStats']
2022-12-14 23:04:25 [scrapy.middleware] INFO: Enabled spider middlewares:
['scrapy.spidermiddlewares.httperror.HttpErrorMiddleware',
 'scrapy.spidermiddlewares.offsite.OffsiteMiddleware',
 'scrapy.spidermiddlewares.referer.RefererMiddleware',
 'scrapy.spidermiddlewares.urllength.UrlLengthMiddleware',
 'scrapy.spidermiddlewares.depth.DepthMiddleware']
2022-12-14 23:04:25 [scrapy.middleware] INFO: Enabled item pipelines:
[]
2022-12-14 23:04:25 [scrapy.core.engine] INFO: Spider opened
2022-12-14 23:04:25 [scrapy.extensions.logstats] INFO: Crawled 0 pages (at 0 pages/min), scraped 0 items (at 0 items/min)
2022-12-14 23:04:25 [scrapy.extensions.telnet] INFO: Telnet console listening on 127.0.0.1:6023
2022-12-14 23:04:30 [scrapy.core.engine] INFO: Closing spider (finished)
2022-12-14 23:04:30 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'downloader/request_bytes': 247,
 'downloader/request_count': 1,
 'downloader/request_method_count/GET': 1,
 'downloader/response_bytes': 23356,
 'downloader/response_count': 1,
 'downloader/response_status_count/200': 1,
 'elapsed_time_seconds': 5.207117,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2022, 12, 15, 4, 4, 30, 406995),
 'log_count/DEBUG': 12,
 'log_count/INFO': 10,
 'log_count/WARNING': 2,
 'memusage/max': 66682880,
 'memusage/startup': 66682880,
 'response_received_count': 1,
 'scheduler/dequeued': 1,
 'scheduler/dequeued/memory': 1,
 'scheduler/enqueued': 1,
 'scheduler/enqueued/memory': 1,
 'start_time': datetime.datetime(2022, 12, 15, 4, 4, 25, 199878)}
2022-12-14 23:04:30 [scrapy.core.engine] INFO: Spider closed (finished)

cat delinquent_tax_processed.csv | wc -l
    4882
```